### PR TITLE
Use correct data type for boolean flags

### DIFF
--- a/client.go
+++ b/client.go
@@ -75,16 +75,16 @@ type (
 		MemTotal           int64
 		Name               string
 		ID                 string
-		Debug              int
+		Debug              bool
 		NFd                int
 		NGoroutines        int
 		NEventsListener    int
 		InitPath           string
 		InitSha1           string
 		IndexServerAddress string
-		MemoryLimit        int
-		SwapLimit          int
-		IPv4Forwarding     int
+		MemoryLimit        bool
+		SwapLimit          bool
+		IPv4Forwarding     bool
 		Labels             []string
 		DockerRootDir      string
 		OperatingSystem    string


### PR DESCRIPTION
Docker API 1.19 changes the data type for some flags in `/info` from integer to boolean. This causes the Go json decoder to fail with an unmarshalling error because the target data type is not `bool`.

The most visible effect of this (undocumented) change is cpuguy83/docker-volumes#30.

Note that this _will_ break talking with older Docker versions, because for some reason 1.7.0 retroactively changed the data type of those flags to `boolean` for _all_ API versions instead of limiting the type change to API 1.19.
